### PR TITLE
Updates to edit_attribute

### DIFF
--- a/R/edit_attribute.R
+++ b/R/edit_attribute.R
@@ -17,7 +17,7 @@
 #' @param definition The new definition (for textDomain) to give to the attribute
 #' @param formatString The new formatString to give to the attribute
 #' @param missingValueCode The new missing value code to give to the attribute
-#' @param missingValueCodeExplanation The new missing value code explaination to give to the attribute
+#' @param missingValueCodeExplanation The new missing value code explanation to give to the attribute
 #'
 #' @export
 #'
@@ -38,7 +38,7 @@ edit_attribute <- function(eml, dataTableNumber, attributeNumber, attributeName 
                            missingValueCode = NULL, missingValueCodeExplanation = NULL){
 
     data <- EML::get_attributes(eml@dataset@dataTable[[dataTableNumber]]@attributeList)
-    attributeTable <- data.frame(data$attributes) #this excludes the factor table from enumerated domain.
+    attributeTable <-data$attributes #this excludes the factor table from enumerated domain.
 
     if(!is.null(attributeName)) {
         attributeTable$attributeName[attributeNumber] <- attributeName
@@ -64,6 +64,12 @@ edit_attribute <- function(eml, dataTableNumber, attributeNumber, attributeName 
     if(!is.null(formatString)) {
         attributeTable$formatString[attributeNumber] <- formatString
     }
+
+    if((is.null(missingValueCode) & !is.null(missingValueCodeExplanation)) |
+    (!is.null(missingValueCode) & is.null(missingValueCodeExplanation))){
+        stop("Need both missingValueCode and missingValueCodeExplanation")
+    }
+
     if(!is.null(missingValueCode)) {
         attributeTable$missingValueCode[attributeNumber] <- missingValueCode
     }
@@ -73,7 +79,6 @@ edit_attribute <- function(eml, dataTableNumber, attributeNumber, attributeName 
 
     attribute_list <- EML::set_attributes(attributeTable, factors = data$factors)
     eml@dataset@dataTable[[dataTableNumber]]@attributeList <- attribute_list
-    return(eml)
     EML:::check_and_complete_attributes(attributeTable, NULL)
-
+    return(eml)
 }

--- a/R/edit_attribute.R
+++ b/R/edit_attribute.R
@@ -40,41 +40,16 @@ edit_attribute <- function(eml, dataTableNumber, attributeNumber, attributeName 
     data <- EML::get_attributes(eml@dataset@dataTable[[dataTableNumber]]@attributeList)
     attributeTable <-data$attributes #this excludes the factor table from enumerated domain.
 
-    if(!is.null(attributeName)) {
-        attributeTable$attributeName[attributeNumber] <- attributeName
-    }
-    if(!is.null(attributeDefinition)) {
-        attributeTable$attributeDefinition[attributeNumber] <- attributeDefinition
-    }
-    if(!is.null(measurementScale)) {
-        attributeTable$measurementScale[attributeNumber] <- measurementScale
-    }
-    if(!is.null(domain)) {
-        attributeTable$domain[attributeNumber] <- domain
-    }
-    if(!is.null(unit)) {
-        attributeTable$unit[attributeNumber] <- unit
-    }
-    if(!is.null(numberType)) {
-        attributeTable$numberType[attributeNumber] <- numberType
-    }
-    if(!is.null(definition)) {
-        attributeTable$definition[attributeNumber] <- definition
-    }
-    if(!is.null(formatString)) {
-        attributeTable$formatString[attributeNumber] <- formatString
-    }
-
-    if((is.null(missingValueCode) & !is.null(missingValueCodeExplanation)) |
-    (!is.null(missingValueCode) & is.null(missingValueCodeExplanation))){
+    if(length(c(missingValueCode, missingValueCodeExplanation)) == 1){
         stop("Need both missingValueCode and missingValueCodeExplanation")
     }
 
-    if(!is.null(missingValueCode)) {
-        attributeTable$missingValueCode[attributeNumber] <- missingValueCode
-    }
-    if(!is.null(missingValueCodeExplanation)) {
-        attributeTable$missingValueCodeExplanation[attributeNumber] <- missingValueCodeExplanation
+    attribute_edits <- cbind(attributeName, attributeDefinition, domain,
+                        measurementScale, unit, numberType, definition, formatString,
+                        missingValueCode, missingValueCodeExplanation)
+
+    for(i in colnames(attribute_edits)){
+        attributeTable[,i][attributeNumber] <- attribute_edits[,i]
     }
 
     attribute_list <- EML::set_attributes(attributeTable, factors = data$factors)

--- a/man/edit_attribute.Rd
+++ b/man/edit_attribute.Rd
@@ -35,7 +35,7 @@ edit_attribute(eml, dataTableNumber, attributeNumber, attributeName = NULL,
 
 \item{missingValueCode}{The new missing value code to give to the attribute}
 
-\item{missingValueCodeExplanation}{The new missing value code explaination to give to the attribute}
+\item{missingValueCodeExplanation}{The new missing value code explanation to give to the attribute}
 }
 \description{
 This function edits the slots of a single attribute in an existing attribute table.

--- a/tests/testthat/test_edit_attribute.R
+++ b/tests/testthat/test_edit_attribute.R
@@ -41,3 +41,9 @@ testthat::test_that("error occurs if incorrect combinations occur between measur
     testthat::expect_error(edit_attribute(eml, 1, 2, attributeDefinition = "test definition", domain = "numericDomain",
                                             measurementScale = "dateTime", unit = "dimensionless", numberType = "whole", definition = 'NA'))
 })
+
+testthat::test_that("error occurs if you specify either missingValueCode or missing ValueCodeExplanation but not both", {
+
+    testthat::expect_error(edit_attribute(eml, 1, 2, missingValueCode = "testValueCode"))
+    testthat::expect_error(edit_attribute(eml, 1, 2, missingValueCode = "testExplanation"))
+})


### PR DESCRIPTION
(1) Correct typo in documentation, (2) add error message if user specifies either a missingValueCode or missingValueCodeExplanation but not both, (3) move return(eml) call to very end of the function, (4) add test to test file for missingValueCode error