### PR TITLE
remove setting a token for the mn that copy_package pulls from

### DIFF
--- a/R/clone_package.R
+++ b/R/clone_package.R
@@ -345,9 +345,6 @@ copy_package <- function(resource_map_pid,
                          to,
                          public = FALSE,
                          clone_children = FALSE) {
-    if (!arcticdatautils::is_token_set(from@mn)) {
-        stop("No token is set for member node: ", from@mn@identifier)
-    }
     if (!arcticdatautils::is_token_set(to@mn)) {
         stop("No token is set for member node: ", to@mn@identifier)
     }


### PR DESCRIPTION
`copy_package` required a token from the member node that it copies from.  This isn't necessary as in most cases the content is public.  