### PR TITLE
added additional support for reading tabular data in qa_package

### DIFF
--- a/man/qa_attributes.Rd
+++ b/man/qa_attributes.Rd
@@ -4,7 +4,8 @@
 \alias{qa_attributes}
 \title{Check congruence of data and metadata attributes for a tabular data object}
 \usage{
-qa_attributes(entity, data, eml = NULL)
+qa_attributes(entity, data, eml = NULL, check_attribute_classes, skip,
+  header_row_number)
 }
 \arguments{
 \item{entity}{(eml) An EML \code{dataTable}, \code{otherEntity}, or \code{spatialVector} associated with the data object.}
@@ -12,6 +13,17 @@ qa_attributes(entity, data, eml = NULL)
 \item{data}{(data.frame) A data frame of the data object.}
 
 \item{eml}{(S4) The entire EML object. This is necessary if attributes with references are being checked.}
+
+\item{check_attribute_classes}{(logical) Check if column types match attribute measurementscale.  For example "ratio"
+measurementScale should contain integer or numeric data.  These checks often fail, for example read.table will often read
+in dateTime formats as character values - which triggers a warning.  Set \code{check_attribute_classes = FALSE} to skip
+these checks.}
+
+\item{skip}{(integer) The number of rows to skip when reading in data files.  This is useful when any metadata lines above the data}
+
+\item{header_row_number}{(integer) The row number of the data column headers.  If it's the first line then leave
+this parameter as \code{NULL}.  If you also set a value for the \code{skip} parameter do not take that into account.
+This should be the line where the headers appear in the original file, regardless of lines skipped when reading it in.}
 }
 \value{
 \code{NULL}

--- a/man/qa_package.Rd
+++ b/man/qa_package.Rd
@@ -6,7 +6,8 @@
 \usage{
 qa_package(mn, resource_map_pid, read_all_data = TRUE,
   check_attributes = TRUE, check_creators = FALSE,
-  check_access = FALSE)
+  check_access = FALSE, check_attribute_classes = TRUE, skip = 0,
+  delimiter = "", header_row_number = NULL)
 }
 \arguments{
 \item{mn}{(MNode) The Member Node to query.}
@@ -23,6 +24,20 @@ If \code{check_attributes = FALSE}, no rows will be read.}
 
 \item{check_access}{(logical) Check if each creator has full access to the metadata, resource map, and data objects.
 Will not run if the checks associated with \code{check_creators} fail.}
+
+\item{check_attribute_classes}{(logical) Check if column types match attribute measurementscale.  For example "ratio"
+measurementScale should contain integer or numeric data.  These checks often fail, for example read.table will often read
+in dateTime formats as character values - which triggers a warning.  Set \code{check_attribute_classes = FALSE} to skip
+these checks.}
+
+\item{skip}{(integer) The number of rows to skip when reading in data files.  This is useful when any metadata lines above the data
+contain fewer columns than the data.  Skip these rows to avoid an error reading in tabular data.}
+
+\item{delimiter}{(character) the field separator character. Values on each line of the file are separated by this character.}
+
+\item{header_row_number}{(integer) The row number of the data column headers.  If it's the first line then leave
+this parameter as \code{NULL}.  If you also set a value for the \code{skip} parameter do not take that into account.
+This should be the line where the headers appear in the original file, regardless of lines skipped when reading it in.}
 }
 \value{
 \code{NULL}


### PR DESCRIPTION
Added the following parameters to `qa_package` to support tabular data with varying header metadata. 

+ `check_attribute_classes` (logical) True or False. Check if column types match attribute measurementscale.  For example a "ratio" measurementScale should contain integer or numeric data.  These checks often fail. For example read.table will read in dateTime formats as character values - which triggers a warning.  We can set this to FALSE to skip these checks. 
+ `skip` The number of rows to skip when reading in data files.  This is useful when any metadata lines above the data contain fewer columns than the data.  Skip these rows to avoid an error reading in tabular data.
+ `delimiter` the field separator character. Values on each line of the file are separated by this 
+ `header_row_number` (integer) The row number of the data column headers.  If it's the first line then leave as `NULL`