### PR TITLE
account for LTER and EDI datasets  in `categorize_dataset`

### DIFF
--- a/R/categorize_dataset.R
+++ b/R/categorize_dataset.R
@@ -21,7 +21,7 @@
 categorize_dataset <- function(doi, themes, coder, test = F, overwrite = F){
 
   stopifnot(length(themes) > 0 & length(themes) < 5)
-  stopifnot(grepl("doi", doi))
+  stopifnot(grepl("doi|pasta.lternet.edu/package/metadata/eml", doi))
 
   #check if there is googlesheet token already
   if(!googlesheets4::gs4_has_token()){


### PR DESCRIPTION
datasets from LTER and EDI that don't use the DOI in the metadata pid. Make sure to include that in the `stopifnot` check in the beginning.